### PR TITLE
Implement project stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# GA LLM World Model
+
+This project implements a simplified molecular design workflow combining a LangGraph based language model agent, a Graph GA generator, and a world model with a risk gate.
+
+## Installation
+
+```bash
+conda create -n molwm python=3.9 && conda activate molwm
+pip install torch==2.* torch_geometric==2.* rdkit-pypi \
+    guacamol==0.5.2 guacamol-baselines langgraph==0.4.*
+```
+
+## Usage
+
+Pretrain the world model:
+
+```bash
+python training/train_pretrain.py --epochs 50
+```
+
+Fine-tune the model:
+
+```bash
+python training/train_finetune.py --epochs 30
+```
+
+Single SMILES inference:
+
+```bash
+python inference.py \
+   --smiles "CC1=CC(=O)NC(=O)N1" \
+   --task_name "logP" --op ">=" --value 2.5
+```
+
+Run the GuacaMol benchmark suite:
+
+```bash
+python benchmark/guacamol_runner.py --oracle_budget 200
+```

--- a/agent/graph_ga_wrapper.py
+++ b/agent/graph_ga_wrapper.py
@@ -1,0 +1,15 @@
+"""Wrapper for GB_GA_generate from guacamol_baselines."""
+from typing import List, Callable
+
+try:
+    from guacamol_baselines.graph_ga.goal_directed_generation import GB_GA_generate
+except Exception:  # pragma: no cover - fallback when package missing
+    GB_GA_generate = None
+
+
+def ga_generate(n: int, scoring_function: Callable[[str], float]) -> List[str]:
+    """Generate ``n`` SMILES using the Graph GA baseline."""
+    if GB_GA_generate is None:
+        # TODO: handle package not available
+        return ["C" for _ in range(n)]
+    return GB_GA_generate(scoring_function, number_molecules=n)

--- a/agent/llm_agent.py
+++ b/agent/llm_agent.py
@@ -1,0 +1,15 @@
+"""LangGraph based language model agent."""
+from typing import List
+
+
+class LangGraphAgent:
+    """Simple stub for a LangGraph driven LLM agent."""
+
+    def __init__(self):
+        # TODO: integrate real LangGraph nodes and planning
+        pass
+
+    def generate(self, n: int, task_emb) -> List[str]:
+        """Return ``n`` SMILES strings.``task_emb`` is unused in this stub."""
+        # In a real system this would use LangGraph to plan and call an LLM.
+        return ["C" for _ in range(n)]

--- a/agent/policy.py
+++ b/agent/policy.py
@@ -1,0 +1,27 @@
+"""Meta-controller deciding between LLM agent and Graph GA."""
+from typing import Callable, List
+
+
+class MetaPolicy:
+    """A very simple multi-armed bandit style policy."""
+
+    def __init__(self, llm_agent_generate: Callable, ga_generate: Callable, window: int = 50):
+        self.llm_agent_generate = llm_agent_generate
+        self.ga_generate = ga_generate
+        self.window = window
+        self.history: List[float] = []
+
+    def update(self, value: float) -> None:
+        self.history.append(value)
+        if len(self.history) > self.window:
+            self.history.pop(0)
+
+    def next_generator(self) -> Callable:
+        """Select next generator based on moving average reward."""
+        if not self.history:
+            return self.llm_agent_generate
+        avg = sum(self.history) / len(self.history)
+        # Toy strategy: alternate depending on avg threshold
+        if avg > 0.5:
+            return self.llm_agent_generate
+        return self.ga_generate

--- a/benchmark/guacamol_runner.py
+++ b/benchmark/guacamol_runner.py
@@ -1,0 +1,52 @@
+"""Run GuacaMol benchmark suite with the hybrid generator."""
+import argparse
+from typing import List
+
+from guacamol.benchmark_suites import goal_directed_benchmark_suite
+from guacamol.scoring_function import ScoringFunction
+
+from agent.llm_agent import LangGraphAgent
+from agent.graph_ga_wrapper import ga_generate
+from agent.policy import MetaPolicy
+from world_model import config, data_utils, encoder, heads, gate, task_encoder
+from oracle import dft_proxy
+
+
+def run_task(scoring_function: ScoringFunction, policy: MetaPolicy, task_name: str) -> float:
+    llm = policy.llm_agent_generate
+    gen_fn = policy.next_generator()
+    smiles_list = gen_fn(5, None)
+    scores = []
+    for smi in smiles_list:
+        mol = data_utils.smiles_to_mol(smi)
+        fp = data_utils.mol_to_fp(mol)
+        rep = encoder.MoleculeEncoder()(fp)
+        props = heads.PropertyHeads(rep.shape[-1])(rep)
+        novelty = rep.norm() * 0.0
+        risk = gate.RiskGate()(props, novelty)
+        if risk <= config.RISK_THRESHOLD:
+            score = scoring_function.score(smi)
+        else:
+            score = 0.0
+        policy.update(risk.item() * score)
+        scores.append(score)
+    return sum(scores) / len(scores)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--oracle_budget", type=int, default=200)
+    args = parser.parse_args()
+    suite = goal_directed_benchmark_suite()
+    llm_agent = LangGraphAgent()
+    policy = MetaPolicy(llm_agent.generate, ga_generate)
+    results: List[float] = []
+    for benchmark in suite:
+        score = run_task(benchmark.scoring_function, policy, benchmark.name)
+        results.append(score)
+        print(f"{benchmark.name}: {score:.3f}")
+    print(f"Average score: {sum(results)/len(results):.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,25 @@
+"""Inference script for a single SMILES."""
+import argparse
+
+from world_model import data_utils, encoder, heads, gate, task_encoder
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--smiles", required=True)
+    parser.add_argument("--task_name", required=True)
+    parser.add_argument("--op", required=True)
+    parser.add_argument("--value", type=float, required=True)
+    args = parser.parse_args()
+
+    mol = data_utils.smiles_to_mol(args.smiles)
+    fp = data_utils.mol_to_fp(mol)
+    rep = encoder.MoleculeEncoder()(fp)
+    props = heads.PropertyHeads(rep.shape[-1])(rep)
+    novelty = rep.norm() * 0.0
+    risk = gate.RiskGate()(props, novelty)
+    print(f"Risk: {risk.item():.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/oracle/dft_proxy.py
+++ b/oracle/dft_proxy.py
@@ -1,0 +1,9 @@
+"""Proxy for an expensive DFT oracle."""
+import random
+
+
+def evaluate(smiles: str) -> float:
+    """Return a fake oracle score for the molecule."""
+    # TODO: replace with real model or DFT call
+    random.seed(hash(smiles) % (2**32))
+    return random.random()

--- a/training/train_finetune.py
+++ b/training/train_finetune.py
@@ -1,0 +1,14 @@
+"""Weakly-supervised finetuning stub."""
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--epochs", type=int, default=1)
+    args = parser.parse_args()
+    # TODO: implement finetuning
+    print(f"Finetuning for {args.epochs} epochs...")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/train_pretrain.py
+++ b/training/train_pretrain.py
@@ -1,0 +1,14 @@
+"""Self-supervised pretraining stub."""
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--epochs", type=int, default=1)
+    args = parser.parse_args()
+    # TODO: implement pretraining
+    print(f"Pretraining for {args.epochs} epochs...")
+
+
+if __name__ == "__main__":
+    main()

--- a/world_model/config.py
+++ b/world_model/config.py
@@ -1,0 +1,4 @@
+"""Configuration for the world model."""
+
+ORACLE_BUDGET = 500
+RISK_THRESHOLD = 0.5

--- a/world_model/data_utils.py
+++ b/world_model/data_utils.py
@@ -1,0 +1,17 @@
+"""Utilities for converting SMILES to model features."""
+from typing import Any
+
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+
+def smiles_to_mol(smiles: str) -> Any:
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"Invalid SMILES: {smiles}")
+    return mol
+
+
+def mol_to_fp(mol: Any) -> Any:
+    # Morgan fingerprint as placeholder feature
+    return AllChem.GetMorganFingerprintAsBitVect(mol, radius=2, nBits=2048)

--- a/world_model/encoder.py
+++ b/world_model/encoder.py
@@ -1,0 +1,16 @@
+"""Stub SE(3)-Transformer style encoder."""
+from typing import Any
+import torch
+from torch import nn
+
+
+class MoleculeEncoder(nn.Module):
+    """Placeholder encoder returning a fixed-size vector."""
+
+    def __init__(self, dim: int = 256):
+        super().__init__()
+        self.fc = nn.Linear(2048, dim)
+
+    def forward(self, fp: Any) -> torch.Tensor:
+        x = torch.tensor(list(fp), dtype=torch.float32)
+        return self.fc(x)

--- a/world_model/gate.py
+++ b/world_model/gate.py
@@ -1,0 +1,29 @@
+"""Risk gate implementation."""
+from typing import Dict
+import torch
+from torch import nn
+
+
+def sigmoid(x: torch.Tensor) -> torch.Tensor:
+    return torch.sigmoid(x)
+
+
+class RiskGate(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weights = nn.Parameter(torch.ones(5))
+
+    def forward(self, props: Dict[str, torch.Tensor], novelty: torch.Tensor) -> torch.Tensor:
+        p_synth = props["p_synth"]
+        p_tox = props["p_tox"]
+        sigma_sum = props["sigma_sum"]
+        cost_norm = props["cost_norm"]
+        x = torch.stack([
+            1 - p_synth,
+            p_tox,
+            sigma_sum,
+            cost_norm,
+            novelty,
+        ])
+        risk = sigmoid((self.weights * x).sum())
+        return risk

--- a/world_model/heads.py
+++ b/world_model/heads.py
@@ -1,0 +1,23 @@
+"""Multiple prediction heads for the world model."""
+from typing import Dict
+import torch
+from torch import nn
+
+
+class PropertyHeads(nn.Module):
+    """Placeholder heads predicting synthesis, toxicity etc."""
+
+    def __init__(self, in_dim: int, dropout: float = 0.1):
+        super().__init__()
+        self.synth = nn.Sequential(nn.Linear(in_dim, 1), nn.Sigmoid())
+        self.tox = nn.Sequential(nn.Linear(in_dim, 1), nn.Sigmoid())
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor) -> Dict[str, torch.Tensor]:
+        x = self.dropout(x)
+        return {
+            "p_synth": self.synth(x).squeeze(-1),
+            "p_tox": self.tox(x).squeeze(-1),
+            "sigma_sum": x.std().unsqueeze(0),
+            "cost_norm": torch.sigmoid(x.mean()).unsqueeze(0),
+        }

--- a/world_model/planner.py
+++ b/world_model/planner.py
@@ -1,0 +1,8 @@
+"""Stub retrosynthesis planner."""
+from typing import List
+
+
+def plan_retro(smiles: str) -> List[str]:
+    """Return a list of precursor SMILES (stub)."""
+    # TODO: integrate real retrosynthesis planner
+    return [smiles]

--- a/world_model/task_encoder.py
+++ b/world_model/task_encoder.py
@@ -1,0 +1,19 @@
+"""Task encoder supporting GuacaMol benchmark suite."""
+from typing import List
+import torch
+from torch import nn
+
+from guacamol.benchmark_suites import goal_directed_benchmark_suite
+
+TASK_LIST = [b.name for b in goal_directed_benchmark_suite()]
+
+
+class TaskEncoder(nn.Module):
+    def __init__(self, dim: int = 128):
+        super().__init__()
+        self.embed = nn.Embedding(len(TASK_LIST), dim)
+
+    def forward(self, task_name: str) -> torch.Tensor:
+        idx = TASK_LIST.index(task_name)
+        idx_tensor = torch.tensor(idx, dtype=torch.long)
+        return self.embed(idx_tensor)


### PR DESCRIPTION
## Summary
- add README with setup and usage instructions
- implement agent stubs for LangGraph agent, Graph GA wrapper and policy
- create world model modules and risk gate
- create oracle placeholder and training scripts
- add benchmark runner and inference script

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845973f7d0c832292a18da50914a1f0